### PR TITLE
quick fix for evaluation session_number and params issue

### DIFF
--- a/app/controllers/admin/base_controller.rb
+++ b/app/controllers/admin/base_controller.rb
@@ -13,11 +13,11 @@ class Admin::BaseController < ApplicationController
 
     def set_evaluation
       @evaluations = Evaluation.all
-      Evaluation.current_evaluation = params[:evaluation].present? ? Evaluation.find(params[:evaluation]) : nil
+      Evaluation.current_evaluation = params[:current_evaluation_id].present? ? Evaluation.find(params[:current_evaluation_id]) : nil
       @evaluation = Evaluation.current_evaluation
     end
 
     def default_url_options(options={})
-      { evaluation: params[:evaluation].present? ? params[:evaluation] : nil}
+      { current_evaluation_id: params[:current_evaluation_id].present? ? params[:current_evaluation_id] : nil}
     end
 end

--- a/app/models/evaluation.rb
+++ b/app/models/evaluation.rb
@@ -21,12 +21,16 @@ class Evaluation < ActiveRecord::Base
   has_many :interpellations
   has_many :events
   belongs_to :term
-  enum session_number: ["1", "2"]
 
   delegate :term_number, to: :term
 
-  validates_presence_of :session_number
-  validates_uniqueness_of :session_number, scope: :term_id
+  validates :session_number, 
+            presence: true, 
+            uniqueness: {scope: :term_id}, 
+            numericality: {
+              greater_than: 0,
+              less_than_or_equal_to: 8
+            }
 
   after_save :inactive_other_evaluations
 

--- a/app/views/admin/_evaluation_dropdown.html.erb
+++ b/app/views/admin/_evaluation_dropdown.html.erb
@@ -5,7 +5,7 @@
   </a>
   <ul class="dropdown-menu">
     <% @evaluations.each do |evaluation| %>
-      <li><%= link_to(evaluation.full_name, params.merge(evaluation: evaluation.id)) %></li>
+      <li><%= link_to(evaluation.full_name, params.merge(current_evaluation_id: evaluation.id)) %></li>
     <% end %>
   </ul>
 </div>

--- a/app/views/admin/evaluations/_form.html.erb
+++ b/app/views/admin/evaluations/_form.html.erb
@@ -1,7 +1,7 @@
 <div class="row">
   <div class="col-xs-12">
     <%= f.association :term, collection: Term.all.map{|term|[term.term_number, term.id]}, label: "屆次" %>
-    <%= f.input :session_number, as: :select, collection: Evaluation.session_numbers.keys.to_a, label: "第幾會期", include_blank: false %>
+    <%= f.input :session_number, label: "第幾會期" %>
   </div>
   <h3>評鑑題目</h3>
   <%= f.simple_fields_for :questions do |question| %>


### PR DESCRIPTION
https://trello.com/c/cXjnTxvh/27-update-the-structure-of-session-number
1. 移除了 evaluation.session_number 的 enum，並且加上了 integer 的驗證
2. 調整了 Admin::BaseController 的 default_url_options，修復新增 evaluation 導致 url 爆炸的問題
